### PR TITLE
feat:add internationalization for free tools

### DIFF
--- a/client/src/components/pages/FreeTools/FreeToolsContent.tsx
+++ b/client/src/components/pages/FreeTools/FreeToolsContent.tsx
@@ -247,7 +247,6 @@ const FreeToolsContent = memo(() => {
   if (isLoading) {
     return <ServicePageSkeleton />;
   }
-  console.log(freeToolItem);
   if (!freeToolItem?.Header.text) return;
 
   const url = generate_item_url_from_name(freeToolItem?.name);

--- a/client/src/i18n/routing.ts
+++ b/client/src/i18n/routing.ts
@@ -15,6 +15,16 @@ export const routing = defineRouting({
       de: "/dienstleistungen/[item]",
       "pt-BR": "/serviços/[item]",
     },
+    "/free-tools": {
+      "es-ES": "/herramientas-gratis",
+      de: "/kostenlose-tools",
+      "pt-BR": "/ferramentas-gratuitas",
+    },
+    "/free-tools/[item]": {
+      "es-ES": "/herramientas-gratis/[item]",
+      de: "/kostenlose-tools/[item]",
+      "pt-BR": "/ferramentas-gratuitas/[item]",
+    },
   },
   localePrefix: "as-needed",
 });


### PR DESCRIPTION
## Summary by Sourcery

Add internationalization (i18n) routing for free tools pages

New Features:
- Add localized routes for free tools pages in Spanish, German, and Brazilian Portuguese

Enhancements:
- Remove console.log statement from FreeToolsContent component