### PR TITLE
feat:add blogs template

### DIFF
--- a/client/src/app/[locale]/blog/[item]/page.tsx
+++ b/client/src/app/[locale]/blog/[item]/page.tsx
@@ -1,0 +1,32 @@
+import BlogsDetailHero from "@/components/pages/Blogs/BlogsDetail/BlogsDetailHero";
+import BlogsDetailMain from "@/components/pages/Blogs/BlogsDetail/BlogsDetailMain";
+import BlogsDetailRelated from "@/components/pages/Blogs/BlogsDetail/BlogsDetailRelated";
+import { getOriginalBlogsItem } from "@/i18n/freeBlogsItemMappings";
+import { BlogsProvider } from "@/providers/BlogsProvider";
+import { notFound, redirect } from "next/navigation";
+
+export default async function BlogDetailPage({
+  params,
+}: {
+  params: Promise<{ locale: string; item: string }>;
+}) {
+  const { locale, item } = await params;
+  const originalItem = await getOriginalBlogsItem(item, locale);
+  if (!originalItem) {
+    notFound();
+  }
+  if (item != originalItem) {
+    let basePath = "/free-tools";
+    if (locale === "es-ES") basePath = "/herramientas-gratis";
+    else if (locale === "de") basePath = "/kostenlose-tools";
+    else if (locale === "pt-BR") basePath = "/ferramentas-gratuitas";
+    redirect(`${basePath}/${originalItem}`);
+  }
+  return (
+    <BlogsProvider item={originalItem} locale={locale}>
+      <BlogsDetailHero />
+      <BlogsDetailMain />
+      <BlogsDetailRelated />
+    </BlogsProvider>
+  );
+}

--- a/client/src/app/[locale]/blog/layout.tsx
+++ b/client/src/app/[locale]/blog/layout.tsx
@@ -1,0 +1,20 @@
+import { routing } from "@/i18n/routing";
+import { BlogsListProvider } from "@/providers/BlogsListProvider";
+import { hasLocale, Locale } from "next-intl";
+import { setRequestLocale } from "next-intl/server";
+import { notFound } from "next/navigation";
+
+export default async function LocaleLayout({
+  children,
+  params,
+}: Readonly<{
+  children: React.ReactNode;
+  params: Promise<{ locale: Locale }>;
+}>) {
+  const { locale } = await params;
+  if (!hasLocale(routing.locales, locale)) {
+    notFound();
+  }
+  setRequestLocale(locale);
+  return <BlogsListProvider locale={locale}>{children}</BlogsListProvider>;
+}

--- a/client/src/app/[locale]/blog/page.tsx
+++ b/client/src/app/[locale]/blog/page.tsx
@@ -1,0 +1,11 @@
+import BlogsHero from "@/components/pages/Blogs/BlogsHero";
+import Posts from "@/components/pages/Blogs/Posts";
+
+export default function BlogPage() {
+  return (
+    <>
+      <BlogsHero />
+      <Posts />
+    </>
+  );
+}

--- a/client/src/app/[locale]/layout.tsx
+++ b/client/src/app/[locale]/layout.tsx
@@ -4,6 +4,14 @@ import { hasLocale, Locale, NextIntlClientProvider } from "next-intl";
 import { routing } from "@/i18n/routing";
 import { notFound } from "next/navigation";
 import { getTranslations, setRequestLocale } from "next-intl/server";
+import { Lato } from "next/font/google";
+
+const lato = Lato({
+  weight: ["100", "300", "400", "700", "900"],
+  style: ["normal", "italic"],
+  subsets: ["latin"],
+  display: "swap",
+});
 
 export const viewport: Viewport = {
   width: "device-width",
@@ -70,7 +78,7 @@ export default async function LocaleLayout({
   }
   setRequestLocale(locale);
   return (
-    <html lang={locale}>
+    <html lang={locale} className={lato.className}>
       <body className={`antialiased`}>
         <NextIntlClientProvider>
           <HomeLayout locale={locale}>{children}</HomeLayout>

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -1,5 +1,7 @@
 @import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css");
 @import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Lato:wght@100;300;400;500;700&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -23,6 +25,11 @@
     --background: #0a0a0a;
     --foreground: #ededed;
   }
+}
+
+html {
+  scroll-padding-top: 220px;
+  scroll-behavior: smooth; /* Optional, for smooth scrolling */
 }
 
 body {

--- a/client/src/components/Skeletons.tsx
+++ b/client/src/components/Skeletons.tsx
@@ -74,6 +74,28 @@ export function ServicePageSkeleton() {
   );
 }
 
+export function BlogPageSkeleton() {
+  return (
+    <div className="bg-background-light border-y flex flex-col gap-10 items-center border-black-dark p-5 w-full h-full animate-fade-in">
+      <Skeleton width="60%" height="200px" />
+      <Skeleton width="80%" height="500px" />
+    </div>
+  );
+}
+
+export function BlogDetailPageSkeleton() {
+  return (
+    <div className="bg-background-light border-y flex flex-col gap-10 items-center border-black-dark p-5 w-full h-full animate-fade-in">
+      <Skeleton width="80%" height="300px" />
+      <div className="flex gap-8 w-full justify-center">
+        <Skeleton width="20%" height="400px" />
+        <Skeleton width="40%" height="400px" />
+        <Skeleton width="20%" height="400px" />
+      </div>
+    </div>
+  );
+}
+
 export function CardSkeleton() {
   return (
     <div className="p-4 rounded-xl bg-background-light shadow-soft animate-fade-in">

--- a/client/src/components/pages/Blogs/BlogsDetail/BlogsDetailHero.tsx
+++ b/client/src/components/pages/Blogs/BlogsDetail/BlogsDetailHero.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { BlogDetailPageSkeleton } from "@/components/Skeletons";
+import { useBlogs } from "@/providers/BlogsProvider";
+import { format_blog_date } from "@/utils/functions";
+import Image from "next/image";
+
+export default function BlogsDetailHero() {
+  const { isLoading, blogsItem } = useBlogs();
+  if (isLoading) return <BlogDetailPageSkeleton />;
+  if (!blogsItem) return;
+  return (
+    <section
+      rel="preload"
+      className="flex flex-col m-auto gap-5 items-center pt-5 pb-8 w-full min-h-[320px] px-4 md:px-10 bg-[url('https://cdn.prod.website-files.com/628d4467de238a5806753c9b/67bb4e7dcabf6acfef507865_blogimage.png')] bg-cover bg-center bg-no-repeat"
+    >
+      <p className="font-clash  text-[#effff8] bg-black border-[5px] border-[#f6f6f6] rounded-[25px] order-0 self-center px-3 py-1.5 text-[16px] font-semibold leading-[20px] no-underline">
+        {blogsItem?.article_category.title}
+      </p>
+      <p className="text-black text-center font-clash max-w-[650px] text-[40px] font-semibold leading-[48px]">
+        {blogsItem.title}
+      </p>
+      <div className="flex gap-5">
+        <div className="flex gap-2">
+          <Image
+            src="https://cdn.prod.website-files.com/628d4467de238a5806753c9b/67cf3bc2f48f61a0a8ae14ea_PencilLine.svg"
+            width={20}
+            height={20}
+            alt="pencil_line"
+            className="w-5 h-5"
+          />
+          <p className="font-medium">
+            Updated on: {format_blog_date(blogsItem.date)}
+          </p>
+        </div>
+        <div className="text-[#e0e0e0]">|</div>
+        <div className="flex gap-2">
+          <Image
+            src="https://cdn.prod.website-files.com/628d4467de238a5806753c9b/67cf3b69d0b8bce1143f417e_ClockCountdown.svg"
+            width={20}
+            height={20}
+            alt="pencil_line"
+            className="w-5 h-5"
+          />
+          <p className="font-medium">{blogsItem.readTime}</p>
+        </div>
+      </div>
+      <p className="font-medium">By: {blogsItem.Author.name}</p>
+    </section>
+  );
+}

--- a/client/src/components/pages/Blogs/BlogsDetail/BlogsDetailMain.tsx
+++ b/client/src/components/pages/Blogs/BlogsDetail/BlogsDetailMain.tsx
@@ -1,0 +1,519 @@
+"use client";
+import MainButton from "@/components/Buttons";
+import { StrapiText } from "@/components/StrapiComponents";
+import { SupportedLocale } from "@/libs/types/Types";
+import { useBlogs } from "@/providers/BlogsProvider";
+import {
+  generate_item_url_from_blog_title,
+  generate_name,
+} from "@/utils/functions";
+import { useLocale } from "next-intl";
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
+import ReCAPTCHA from "react-google-recaptcha";
+
+export default function BlogsDetailMain() {
+  const { blogsItem } = useBlogs();
+  const [value, setValue] = useState("");
+  const [load, setLoad] = useState(false);
+  const [expired, setExpired] = useState("false");
+  const [chapter, setChapter] = useState<string | null>(null);
+  const [callbackStatus, setCallbackStatus] = useState(false);
+  const recaptchaRef = useRef(null);
+  const locale = useLocale() as SupportedLocale;
+
+  const [email, setEmail] = useState("");
+  const [userName, setUserName] = useState("");
+  const [comment, setComment] = useState("");
+
+  useEffect(() => {
+    function onScroll() {
+      if (!blogsItem) return;
+      if (!blogsItem.Content) return;
+      if (blogsItem.Content.Chapter.length === 0) return;
+      const sectionIds = blogsItem.Content.Chapter.map(
+        (item) =>
+          item.Header &&
+          generate_item_url_from_blog_title(generate_name(item.Header.text))
+      );
+      if (!sectionIds) return;
+      const offset = 300; // Adjust threshold as needed
+      let foundId = null;
+
+      for (const id of sectionIds) {
+        if (!id) continue;
+        const elem = document.getElementById(id);
+        if (elem) {
+          const rect = elem.getBoundingClientRect();
+          if (rect.top <= offset && rect.bottom > offset) {
+            foundId = id;
+            break;
+          }
+        }
+      }
+      if (foundId !== chapter) {
+        setChapter(foundId);
+      }
+    }
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [blogsItem, chapter]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setLoad(true);
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const SITE_KEY =
+    process.env.RECAPTCHA_SECRET_KEY ||
+    "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI";
+  const handleCaptchaChange = (val: string | null) => {
+    if (val === null) setExpired("true");
+    else setValue(val);
+  };
+
+  if (!blogsItem) return;
+
+  const asyncScriptOnLoad = () => {
+    setCallbackStatus(true);
+  };
+  const validateForm = () => {
+    if (!email || !userName || !comment) {
+      return "All fields are required";
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return "Please enter a valid email";
+    }
+    if (!callbackStatus) {
+      return "reCAPTCHA not loaded";
+    }
+    if (expired) {
+      return "reCAPTCHA expired";
+    }
+    if (!value) {
+      return "Please complete the reCAPTCHA";
+    }
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    // setFormMessage({ text: "", type: "" });
+
+    const validationError = validateForm();
+    if (validationError) {
+      //   setFormMessage({ text: validationError, type: "error" });
+      return;
+    }
+  };
+  return (
+    <section className="stack max-w-[1280px] grid gap-x-8 grid-cols-[0.5fr_1fr_0.5fr] my-4 place-self-center px-10 pb-20">
+      <div className="sticky top-[220px] flex flex-col gap-2 border-r border-[#e2e2e2] h-max pb-3">
+        <p className="font-clash text-[#14141b] text-[18px] mb-3 leading-5 font-semibold">
+          Contents
+        </p>
+        <ol className="font-lato font-semibold text-[15px] text-[#686889] pr-8">
+          {blogsItem.Content?.Chapter.map(
+            (item, index_1) =>
+              item.Header && (
+                <li
+                  className={`py-2 hover:text-primary ${
+                    chapter ==
+                      generate_item_url_from_blog_title(
+                        generate_name(item.Header.text)
+                      ) && "text-primary"
+                  }`}
+                  onClick={() =>
+                    item.Header &&
+                    setChapter(
+                      generate_item_url_from_blog_title(
+                        generate_name(item.Header.text)
+                      )
+                    )
+                  }
+                  key={index_1}
+                >
+                  <a
+                    href={`#${generate_item_url_from_blog_title(
+                      generate_name(item.Header.text)
+                    )}`}
+                  >
+                    <StrapiText data={item.Header.text} />
+                  </a>
+                </li>
+              )
+          )}
+        </ol>
+      </div>
+      <div className="flex flex-col gap-10">
+        {blogsItem.Content?.Chapter.map((item, index_2) => (
+          <div
+            className="flex flex-col gap-5"
+            key={index_2}
+            id={
+              item.Header?.text &&
+              generate_item_url_from_blog_title(generate_name(item.Header.text))
+            }
+          >
+            {item.Header?.text && (
+              <h2>
+                <StrapiText
+                  data={item.Header.text}
+                  customClassName="font-clash text-[32px] font-semibold leading-10 text-black"
+                />
+              </h2>
+            )}
+            {item.img && (
+              <Image
+                src={item.img}
+                width={600}
+                height={400}
+                className="w-full"
+                alt="chapter"
+              />
+            )}
+            {item.Section &&
+              item.Section.map((sectionItem, index_3) => (
+                <div className="flex flex-col gap-5" key={index_3}>
+                  {sectionItem.Header?.text && (
+                    <h3>
+                      <StrapiText
+                        data={sectionItem.Header.text}
+                        customClassName="font-clash text-[24px] font-semibold leading-10 text-black"
+                      />
+                    </h3>
+                  )}
+                  {sectionItem?.img && (
+                    <Image
+                      src={sectionItem.img}
+                      width={600}
+                      height={400}
+                      className="w-full"
+                      alt="chapter"
+                    />
+                  )}
+                  {sectionItem.Subsection &&
+                    sectionItem.Subsection.map((subSectionItem, index_4) => (
+                      <div className="flex flex-col gap-5" key={index_4}>
+                        {subSectionItem.Header?.text && (
+                          <h4>
+                            <StrapiText
+                              data={subSectionItem.Header.text}
+                              customClassName="font-clash text-[18px] font-semibold leading-10 text-black"
+                            />
+                          </h4>
+                        )}
+                        {subSectionItem?.img && (
+                          <Image
+                            src={subSectionItem.img}
+                            width={600}
+                            height={400}
+                            className="w-full"
+                            alt="chapter"
+                          />
+                        )}
+                        {subSectionItem.Paragraph.map(
+                          (paragraphItem, index_5) => (
+                            <div className="flex flex-col gap-5" key={index_5}>
+                              <StrapiText
+                                data={paragraphItem.Sentence.text}
+                                customClassName="font-satoshi text-[18px] text-[#686889]"
+                              />
+                              {paragraphItem.List &&
+                                paragraphItem.List.map((listItem, index_6) => (
+                                  <ul
+                                    key={index_6}
+                                    className={`${
+                                      listItem.numberlist
+                                        ? "list-decimal"
+                                        : "list-disc"
+                                    } ml-5`}
+                                    role="list"
+                                  >
+                                    {listItem.Level1 &&
+                                      listItem.Level1.map(
+                                        (level1Item, index_7) => (
+                                          <li key={index_7}>
+                                            <StrapiText
+                                              data={level1Item.text}
+                                              customClassName="font-satoshi text-[18px] text-[#686889]"
+                                            />
+                                            {level1Item.Level2 && (
+                                              <ul
+                                                className="ml-5"
+                                                style={{
+                                                  listStyleType: "circle",
+                                                }}
+                                              >
+                                                {level1Item.Level2.map(
+                                                  (level2Item, index_8) => (
+                                                    <li key={index_8}>
+                                                      <StrapiText
+                                                        data={level2Item.text}
+                                                        customClassName="font-satoshi text-[18px] text-[#686889]"
+                                                      />
+                                                    </li>
+                                                  )
+                                                )}
+                                              </ul>
+                                            )}
+                                          </li>
+                                        )
+                                      )}
+                                  </ul>
+                                ))}
+                              {paragraphItem.img && (
+                                <Image
+                                  src={paragraphItem.img}
+                                  width={300}
+                                  height={150}
+                                  className="w-[80%] place-self-center"
+                                  alt="paragraph-imag"
+                                />
+                              )}
+                            </div>
+                          )
+                        )}
+                      </div>
+                    ))}
+                </div>
+              ))}
+          </div>
+        ))}
+        <div className="w-full flex flex-col gap-5 bg-[#f6f6f6] border border-[#e2e2e2] rounded-2xl py-8 px-6">
+          <div className="flex gap-4">
+            <Image
+              src={blogsItem.Author.avatar}
+              width={80}
+              height={80}
+              alt="avatar"
+              className="w-20 h-20 rounded-full"
+            />
+            <div className="flex flex-col gap-4">
+              <p className="font-clash text-[14px] font-medium text-primary uppercase">
+                About the author
+              </p>
+              <p className="font-clash text-[24px] font-semibold text-[#14141b]">
+                {blogsItem.Author.name}
+              </p>
+            </div>
+          </div>
+          <p className="font-satoshi text-base text-[#686889] leading-[27px]">
+            {blogsItem.Author.introduction}
+          </p>
+          <div className="flex gap-5">
+            {blogsItem.Author.social.length > 0 &&
+              blogsItem.Author.social.map((socialItem, index) => (
+                <a
+                  key={index}
+                  href={socialItem.link}
+                  className="w-9 h-9 flex items-center justify-center bg-[#e0e0e0] rounded-lg"
+                >
+                  <Image
+                    src={socialItem.img}
+                    width={20}
+                    height={20}
+                    alt="social-img"
+                    className="w-5 h-5"
+                  />
+                </a>
+              ))}
+          </div>
+        </div>
+        <div className="w-full flex flex-col items-center gap-5 bg-[#f6f6f6] border border-[#e2e2e2] rounded-2xl p-5">
+          <div className="flex w-full justify-between items-end pb-6">
+            <h2 className="mt-10 mb-[6px] font-clash text-[24px] text-[#000] font-medium">
+              0 Comments
+            </h2>
+            <div className="h-max border-[1px] border-black-dark flex rounded-md shadow-sm hover:shadow-md transition-shadow duration-300">
+              <div className="bg-[url('https://cdn.prod.website-files.com/628d4467de238a5806753c9b/675716e51edb39c901338e53_flowbite_sort-outline.svg')] bg-[4px_center] bg-no-repeat bg-auto border-r-[1px] border-black-dark text-black text-[16px] font-satoshi leading-6 pl-8 p-2 bg-black-light rounded-l-[10px]">
+                Sort by
+              </div>
+              <select
+                // value={filter}
+                // onChange={handleFilterChange}
+                className="w-30 p-2 mr-2 cursor-pointer bg-inherit text-[16px] rounded-r-md transition-all duration-300"
+              >
+                <option label="Newest" value="Newest">
+                  Newest
+                </option>
+                <option label="Oldest" value="Oldest">
+                  Oldest
+                </option>
+              </select>
+            </div>
+          </div>
+          <div className="flex w-full gap-5 pt-6 pb-[30px] border-y border-[#D0D0D0]">
+            <p className="w-[70px] h-[70px] font-satoshi text-[24px] rounded-full flex justify-center items-center bg-white font-thin">
+              SP
+            </p>
+            <form className="flex-grow flex flex-col gap-5">
+              <div className="flex flex-col">
+                <label
+                  htmlFor="name"
+                  className="mb-2 text-[18px] font-medium font-satoshi"
+                >
+                  Name
+                </label>
+                <input
+                  type="text"
+                  value={userName}
+                  onChange={(e) => setUserName(e.target.value)}
+                  id="name"
+                  placeholder="Your Name"
+                  className="py-4 px-[10px] w-full bg-white border border-[#EBEBEB] rounded-lg"
+                />
+              </div>
+              <div className="flex flex-col">
+                <label
+                  htmlFor="email"
+                  className="mb-2 text-[18px] font-medium font-satoshi"
+                >
+                  Email
+                </label>
+                <input
+                  type="text"
+                  id="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="your@email.com"
+                  className="py-4 px-[10px] w-full bg-white border border-[#EBEBEB] rounded-lg"
+                />
+              </div>
+              <div className="flex flex-col">
+                <label
+                  htmlFor="comment"
+                  className="mb-2 text-[18px] font-medium font-satoshi"
+                >
+                  Comment
+                </label>
+                <textarea
+                  id="comment"
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                  style={{ resize: "vertical" }}
+                  rows={3}
+                  placeholder="Say something good!"
+                  className="py-4 px-[10px] w-full bg-white border border-[#EBEBEB] rounded-lg"
+                />
+              </div>
+              {load && (
+                <ReCAPTCHA
+                  theme="light"
+                  ref={recaptchaRef}
+                  sitekey={SITE_KEY}
+                  onChange={handleCaptchaChange}
+                  lang={locale}
+                  asyncScriptOnLoad={asyncScriptOnLoad}
+                  className="overflow-hidden"
+                />
+              )}
+              <MainButton
+                customClass="mt-4"
+                customChildClass="py-4"
+                type="primary"
+                title="Post"
+                handleClick={handleSubmit}
+              />
+            </form>
+          </div>
+          <div className="px-5 mt-10 py-3 font-satoshi text-base text-[#686889] text-left w-full">
+            No comments yet
+          </div>
+        </div>
+      </div>
+      <div className="sticky top-[220px] max-w-[270px] w-full h-max flex flex-col gap-8">
+        <div className="w-full h-max px-3 pt-4 pb-10 bg-[#f6f6f6] border border-[#e2e2e2] rounded-lg">
+          <Image
+            src="https://cdn.prod.website-files.com/628d4467de238a5806753c9b/67bb4e269296863ae1e5f3b0_airplane.png"
+            width={73}
+            height={69}
+            alt="subscription"
+            className="w-[73px] h-[69px]"
+          />
+          <p className="w-[80%] font-clash text-[20px] font-semibold text-[#14141b] leading-6 text-center mb-2 place-self-center">
+            Subscribe to our newsletter
+          </p>
+          <div className="flex rounded-lg bg-white border border-[#e2e2e2]">
+            <input
+              className="text-[15px] px-4 rounded-lg"
+              placeholder="Email Address"
+            />
+            <button
+              type="submit"
+              className="w-[60px] h-[60px] m-auto rounded-lg"
+            >
+              <Image
+                src="https://cdn.prod.website-files.com/628d4467de238a5806753c9b/62c2077d323bcf8683fb810b_Arrow%20(1).svg"
+                alt="submit"
+                width={20}
+                height={20}
+                className="w-5 h-5 m-auto saturate-200 hue-rotate-180"
+              />
+            </button>
+          </div>
+        </div>
+        <div className="w-full h-max px-3 pt-4 pb-10 flex flex-col gap-5 items-center bg-[#f6f6f6] border border-[#e2e2e2] rounded-lg">
+          <p className="w-[80%] font-clash text-[20px] font-semibold text-[#14141b] leading-6 text-center mb-2 place-self-center">
+            Share this article
+          </p>
+          <div className="flex gap-2">
+            <a
+              href="#"
+              className="bg-[#0076b2] rounded-lg w-11 h-11 flex justify-center items-center"
+            >
+              <Image
+                src="https://cdn.prod.website-files.com/628d4467de238a5806753c9b/67bb5dadfee185c4c094fc3e_Vector.png"
+                width={24}
+                height={24}
+                alt="linkedin"
+                className="w-6 h-6"
+              />
+            </a>
+            <a
+              href="#"
+              className="bg-[#0a6cdb] rounded-lg w-11 h-11 flex justify-center items-center"
+            >
+              <Image
+                src="https://cdn.prod.website-files.com/628d4467de238a5806753c9b/67bb5dd7de30948f36d814c2_mdi_twitter%20(1).png"
+                width={24}
+                height={24}
+                alt="twitter"
+                className="w-6 h-6"
+              />
+            </a>
+            <a
+              href="#"
+              className="bg-[#2543b9] rounded-lg w-11 h-11 flex justify-center items-center"
+            >
+              <Image
+                src="https://cdn.prod.website-files.com/628d4467de238a5806753c9b/67bb5e580b9ce93d4919431e_facebooklogo.png"
+                width={24}
+                height={24}
+                alt="facebook"
+                className="w-6 h-6"
+              />
+            </a>
+            <a
+              href="#"
+              className="bg-[#435785] rounded-lg w-11 h-11 flex justify-center items-center"
+            >
+              <Image
+                src="https://cdn.prod.website-files.com/628d4467de238a5806753c9b/67bb5e9041e4436f8f41b656_tgram.png"
+                width={24}
+                height={24}
+                alt="telegram"
+                className="w-6 h-6"
+              />
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/pages/Blogs/BlogsDetail/BlogsDetailRelated.tsx
+++ b/client/src/components/pages/Blogs/BlogsDetail/BlogsDetailRelated.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useBlogsList } from "@/providers/BlogsListProvider";
+import BlogsItem from "../BlogsItem";
+
+export default function BlogsDetailRelated() {
+  const { blogsList } = useBlogsList();
+  if (!blogsList) return;
+  return (
+    <section className="max-w-[1280px] w-full place-self-center px-10 py-20">
+      <h2 className="font-clash text-center text-[32px] font-semibold text-black mb-12">
+        News & Articles
+      </h2>
+      <div className="flex flex-col items-center md:flex-row gap-5 w-full">
+        {blogsList.slice(0, 3).map((item, index) => (
+          <BlogsItem item={item} key={index} descriptionShow={false} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/pages/Blogs/BlogsHero.tsx
+++ b/client/src/components/pages/Blogs/BlogsHero.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { BlogPageSkeleton } from "@/components/Skeletons";
+import { useBlogsList } from "@/providers/BlogsListProvider";
+import {
+  format_blog_date,
+  generate_item_url_from_blog_title,
+} from "@/utils/functions";
+import Image from "next/image";
+
+export default function BlogsHero() {
+  const { isLoading, blogsList } = useBlogsList();
+  if (isLoading) return <BlogPageSkeleton />;
+  if (!blogsList) return;
+  return (
+    <section className="w-full m-auto mb-10">
+      <div
+        rel="preload"
+        className="flex flex-col gap-5 items-center pt-5 w-full min-h-[220px] bg-[#f5f5f5f7] px-4 md:px-10 bg-[linear-gradient(#f5f5f5f7,#f5f5f5f7),url('https://cdn.prod.website-files.com/628d4467de238a5806753c9b/67bb4de67a2ea65794f385ee_perspective-grid-black.webp')] bg-[position:0_0,50%_0] bg-[size:auto,contain] bg-no-repeat"
+      >
+        <p className="font-service w-max">
+          News & <span className="text-primary">Articles</span>
+        </p>
+        <div className="w-[180px] h-[5px] bg-gradient-to-r from-[#fb9ac100] to-[#00c573] rounded-md" />
+      </div>
+      <a
+        href={`/blog/${generate_item_url_from_blog_title(blogsList[0].title)}`}
+        className="bg-white w-full px-4 mt-[-70px] max-w-[1140px] shadow-soft rounded-lg p-5 flex items-center gap-10 place-self-center"
+      >
+        <div className="w-[55%] overflow-hidden rounded-lg">
+          <Image
+            src={blogsList[0].img}
+            width={600}
+            height={400}
+            className="w-full rounded-lg hover:scale-110 cursor-pointer transition-all duration-500"
+            alt="Preview"
+          />
+        </div>
+        <div className="flex flex-col gap-5 items-start w-[40%]">
+          <h3 className="font-clash text-[#202146] font-semibold text-[24px]">
+            {blogsList[0].title}
+          </h3>
+          <p className="font-satoshi text-[18px] leading-7 text-[#686889] mb-1">
+            {blogsList[0].simpleDescription}
+          </p>
+          <div className="flex gap-2 items-center">
+            <Image
+              src={blogsList[0].Author.avatar}
+              width={30}
+              height={30}
+              alt="User"
+              className="w-[30px] h-[30px] rounded-full"
+            />
+            <div className="flex flex-col gap-1">
+              <p className="text-base font-sans font-bold text-[#14141b]">
+                {blogsList[0].Author.name}
+              </p>
+              <p className="text-[14px] leading-5 font-satoshi text-[#9899ad]">
+                {format_blog_date(blogsList[0].date)}
+              </p>
+            </div>
+          </div>
+        </div>
+      </a>
+    </section>
+  );
+}

--- a/client/src/components/pages/Blogs/BlogsItem.tsx
+++ b/client/src/components/pages/Blogs/BlogsItem.tsx
@@ -1,0 +1,36 @@
+import { Article } from "@/libs/types/BlogsDataType";
+import { generate_item_url_from_blog_title } from "@/utils/functions";
+import Image from "next/image";
+
+interface BlogsItemProps {
+  item: Article;
+  descriptionShow: boolean;
+}
+
+export default function BlogsItem({ item, descriptionShow }: BlogsItemProps) {
+  return (
+    <a
+      href={`/blog/${generate_item_url_from_blog_title(item.title)}`}
+      className="flex flex-col gap-2 items-start max-w-[350px] w-full cursor-pointer"
+    >
+      <Image
+        src={item.img}
+        alt="Blog item image"
+        width={350}
+        height={210}
+        className="w-full rounded-lg"
+      />
+      <p className="font-clash text-[18px] leading-6 text-[#14141b] font-semibold">
+        {item.title}
+      </p>
+      {descriptionShow && (
+        <p className="font-satoshi text-[18px] leading-7 text-[#686889] font-normal">
+          {item.simpleDescription}
+        </p>
+      )}
+      <button className="mt-4 text-base text-primary font-medium">
+        Read More {">"}
+      </button>
+    </a>
+  );
+}

--- a/client/src/components/pages/Blogs/Posts.tsx
+++ b/client/src/components/pages/Blogs/Posts.tsx
@@ -1,0 +1,77 @@
+"use client";
+import BlogsItem from "./BlogsItem";
+import { useState } from "react";
+import { useBlogsList } from "@/providers/BlogsListProvider";
+
+const Categories: string[] = [
+  "Instagram",
+  "Twitter",
+  "NFT",
+  "Discord",
+  "Reddit",
+  "Tiktok",
+  "OnlyFans",
+  "Youtube",
+  "Telegram",
+  "Openesa",
+  "LinkedIn",
+  "Spotify",
+  "GitHub",
+  "Social Media Tips",
+];
+
+export default function Posts() {
+  const [active, setActive] = useState<string[]>([]);
+  const { blogsList } = useBlogsList();
+  if (!blogsList) return;
+  return (
+    <section className="flex flex-col items-center w-full pb-20">
+      <div className="w-full max-w-[1140px] flex flex-col gap-10 px-4">
+        <div className="flex flex-col gap-8 pb-16 border-b border-[#e2e4e8]">
+          <h3 className="font-clash text-[32px] font-semibold leading-5">
+            Latest Posts
+          </h3>
+          <div className="flex flex-col items-center md:flex-row gap-5 w-full">
+            {blogsList.slice(0, 3).map((item, index) => (
+              <BlogsItem item={item} key={index} descriptionShow={true} />
+            ))}
+          </div>
+        </div>
+        <div className="w-full overflow-x-scroll overflow-y-hidden pb-5">
+          <div className="flex gap-5 w-max">
+            {Categories.map((item, index) => (
+              <button
+                className={`w-max hover:bg-primary/50 hover:text-black rounded py-[14px] px-[16px] font-satoshi text-[14px] leading-[14px] font-bold ${
+                  active.includes(item)
+                    ? "bg-primary text-white"
+                    : "bg-[whitesmoke] text-[#a4afbe]"
+                }`}
+                key={index}
+                onClick={() => {
+                  if (active.includes(item)) {
+                    setActive(
+                      active.filter((activeItem) => activeItem !== item)
+                    );
+                  } else {
+                    setActive([...active, item]);
+                  }
+                }}
+              >
+                {item}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="flex flex-col pb-10 items-center w-full sm:grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5">
+          {blogsList.map(
+            (item, index) =>
+              (active.includes(item.article_category.title) ||
+                active.length == 0) && (
+                <BlogsItem item={item} key={index} descriptionShow={false} />
+              )
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/pages/Footer/Followus.tsx
+++ b/client/src/components/pages/Footer/Followus.tsx
@@ -70,7 +70,11 @@ const FollowUs = memo(() => {
           className="w-full px-4 py-3 leading-[22px] text- bg-white text-black placeholder:text-black/50 focus:outline-none focus:border-primary"
           required
         />
-        <MainButton type="primary" title={t("subscribe")} />
+        <MainButton
+          type="primary"
+          customClass="border-none"
+          title={t("subscribe")}
+        />
       </form>
       <FreeTrial />
     </div>

--- a/client/src/components/pages/Footer/FreeTool.tsx
+++ b/client/src/components/pages/Footer/FreeTool.tsx
@@ -73,7 +73,7 @@ const FreeTool = memo(() => {
       label: t("affiliate_program"),
       href: "https://www.socialplug.io/affiliate-program",
     },
-    { label: t("blog"), href: "https://www.socialplug.io/blog" },
+    { label: t("blog"), href: "/blog" },
     { label: t("about_us"), href: "https://www.socialplug.io/about-us" },
     { label: t("reviews"), href: "https://www.socialplug.io/about-us" },
     {

--- a/client/src/components/pages/FreeServices/FreeServicesSections/FreeServicesCustomerReview.tsx
+++ b/client/src/components/pages/FreeServices/FreeServicesSections/FreeServicesCustomerReview.tsx
@@ -76,7 +76,9 @@ const FreeServicesCustomerReview = () => {
                 />
               )
             )}
-            <div className="absolute z-20 bg-[linear-gradient(rgb(0,0,0,0),rgb(255,255,255))] h-[200px] w-full bottom-0 left-0" />
+            {!showLessButton && (
+              <div className="absolute z-20 bg-[linear-gradient(rgb(0,0,0,0),rgb(255,255,255))] h-[200px] w-full bottom-0 left-0" />
+            )}
           </div>
         </div>
       </div>

--- a/client/src/components/pages/NabBar/DropDownServices.tsx
+++ b/client/src/components/pages/NabBar/DropDownServices.tsx
@@ -145,8 +145,8 @@ const DropDownServices = memo(({ item }: DropDownServicesProps) => {
         `}
       >
         {item.type === "Other" ? (
-          <div className="w-[50vw] max-h-[70vh] overflow-y-auto overflow-x-hidden p-1 scrollbar-thin scrollbar-thumb-black-normal scrollbar-track-transparent">
-            <div className="columns-[100px] w-full gap-6">
+          <div className="w-[60vw] max-h-[70vh] overflow-y-auto overflow-x-hidden p-1 scrollbar-thin scrollbar-thumb-black-normal scrollbar-track-transparent">
+            <div className="columns-[150px] w-full gap-6">
               {item.data.map((val, index) => (
                 <ServiceCategory val={val} key={index} />
               ))}

--- a/client/src/components/pages/Services/ServiceCustomerReview/ServiceCustomerReview.tsx
+++ b/client/src/components/pages/Services/ServiceCustomerReview/ServiceCustomerReview.tsx
@@ -82,7 +82,9 @@ const ServiceCustomerReview = () => {
                 key={index}
               />
             ))}
-            <div className="absolute z-20 bg-[linear-gradient(rgb(0,0,0,0),rgb(255,255,255))] h-[200px] w-full bottom-0 left-0" />
+            {!showLessButton && (
+              <div className="absolute z-20 bg-[linear-gradient(rgb(0,0,0,0),rgb(255,255,255))] h-[200px] w-full bottom-0 left-0" />
+            )}
           </div>
         </div>
       </div>

--- a/client/src/i18n/freeBlogsItemMappings.ts
+++ b/client/src/i18n/freeBlogsItemMappings.ts
@@ -1,0 +1,61 @@
+import { BlogsItem } from "@/libs/types/BlogsItemsMapping";
+import { fetchBlogsItemMappings } from "@/utils/fetch-blogs-data";
+import { generate_item_url_from_blog_title } from "@/utils/functions";
+
+export async function initBlogsItemMappings(currentLocale: string) {
+  const blogsItems: BlogsItem[] = await fetchBlogsItemMappings(currentLocale);
+  const mappings: Record<string, Record<string, string>> = {};
+  blogsItems.forEach((item) => {
+    const currentItem =
+      item.locale === currentLocale
+        ? item
+        : item.localizations.find((l) => l.locale === currentLocale);
+    if (!currentItem) return;
+    const currentSlug = generate_item_url_from_blog_title(currentItem.title);
+    if (!mappings[currentSlug]) {
+      mappings[currentSlug] = {};
+    }
+    mappings[currentSlug][item.locale] = generate_item_url_from_blog_title(
+      item.title
+    );
+    if (item.localizations && item.localizations) {
+      item.localizations.forEach((localization) => {
+        mappings[currentSlug][localization.locale] =
+          generate_item_url_from_blog_title(localization.title);
+      });
+    }
+  });
+  return mappings;
+}
+
+export async function getLocalizedFreeToolsItem(
+  item: string,
+  currentLocale: string,
+  nextLocale: string
+): Promise<string> {
+  const mappings = await initBlogsItemMappings(currentLocale);
+  if (!mappings[item]) {
+    return item;
+  }
+  return mappings[item][nextLocale];
+}
+
+const Locales = ["en", "es-ES", "de", "pt-BR"];
+
+export async function getOriginalBlogsItem(
+  localizedItem: string,
+  locale: string
+): Promise<string> {
+  const mappings = await initBlogsItemMappings(locale);
+  for (const [originalItem, translations] of Object.entries(mappings)) {
+    if (translations[locale] === localizedItem) {
+      return originalItem;
+    }
+    for (let i = 0; i < Locales.length; i++) {
+      if (translations[Locales[i]] === localizedItem) {
+        return translations[locale];
+      }
+    }
+  }
+  return "";
+}

--- a/client/src/libs/types/BlogsDataType.ts
+++ b/client/src/libs/types/BlogsDataType.ts
@@ -1,0 +1,113 @@
+import { Text } from "./ServiceJsonDataType";
+
+export interface SocialLink {
+  id: number;
+  link: string;
+  img: string;
+}
+
+export interface Author {
+  id: number;
+  name: string;
+  introduction: string;
+  avatar: string;
+  social: SocialLink[];
+}
+
+// export interface RichText {
+//   id: number;
+//   content: string;
+//   bold: boolean;
+//   link: string | null;
+//   color: string | null;
+//   underline: boolean;
+// }
+
+export interface Header {
+  id: number;
+  icon: string | null;
+  text: Text[];
+}
+
+export interface Level2ListItem {
+  id: number;
+  text: Text[];
+}
+
+export interface Level1ListItem {
+  id: number;
+  Level2: Level2ListItem[];
+  text: Text[];
+}
+
+export interface ParagraphList {
+  id: number;
+  numberlist: boolean;
+  Level1: Level1ListItem[];
+}
+
+export interface Sentence {
+  id: number;
+  icon: string | null;
+  text: Text[];
+}
+
+export interface Paragraph {
+  id: number;
+  img: string | null;
+  Sentence: Sentence;
+  List: ParagraphList[];
+}
+
+export interface Subsection {
+  id: number;
+  img: string | null;
+  Paragraph: Paragraph[];
+  Header: Header | null;
+}
+
+export interface Section {
+  id: number;
+  img: string | null;
+  Header: Header | null;
+  Subsection: Subsection[];
+}
+
+export interface Chapter {
+  id: number;
+  img: string | null;
+  Section: Section[];
+  Header: Header | null;
+}
+
+export interface Content {
+  id: number;
+  Chapter: Chapter[];
+}
+
+export interface ArticleCategory {
+  id: number;
+  documentId: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+}
+
+export interface Article {
+  id: number;
+  documentId: string;
+  title: string;
+  date: string; // ISO date string
+  createdAt: string; // ISO datetime string
+  updatedAt: string; // ISO datetime string
+  publishedAt: string; // ISO datetime string
+  locale: string;
+  img: string;
+  simpleDescription: string;
+  updated: boolean;
+  readTime: string;
+  Author: Author;
+  article_category: ArticleCategory;
+  Content?: Content;
+}

--- a/client/src/libs/types/BlogsItemsMapping.ts
+++ b/client/src/libs/types/BlogsItemsMapping.ts
@@ -1,0 +1,12 @@
+export interface LocalizedBlogsItem {
+  id: number;
+  title: string;
+  locale: "en" | "es-ES" | "pt-BR";
+}
+
+export interface BlogsItem {
+  id: number;
+  title: string;
+  locale: string;
+  localizations: LocalizedBlogsItem[];
+}

--- a/client/src/libs/types/FreeServicesItemsMapping.ts
+++ b/client/src/libs/types/FreeServicesItemsMapping.ts
@@ -4,7 +4,7 @@ export interface LocalizedFreeServicesItem {
   header: {
     text: [{ content: string }];
   };
-  locale: "en" | "es-ES" | "de" | "pt-BR";
+  locale: "en" | "es-ES" | "pt-BR";
 }
 
 export interface FreeServicesItem {

--- a/client/src/libs/types/FreeToolsItemsMapping.ts
+++ b/client/src/libs/types/FreeToolsItemsMapping.ts
@@ -4,7 +4,7 @@ export interface LocalizedFreeToolsItem {
   header: {
     text: [{ content: string }];
   };
-  locale: "en" | "es-ES" | "de" | "pt-BR";
+  locale: "en" | "es-ES" | "pt-BR";
 }
 
 export interface FreeToolsItem {

--- a/client/src/providers/BlogsListProvider.tsx
+++ b/client/src/providers/BlogsListProvider.tsx
@@ -1,0 +1,65 @@
+"use client";
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useMemo,
+} from "react";
+import { Article } from "@/libs/types/BlogsDataType";
+import { fetchAllBlogsList } from "@/utils/fetch-all-blogs-list";
+
+interface BlogsListContextProps {
+  blogsList: Article[] | null;
+  isLoading: boolean;
+}
+
+const BlogsListContext = createContext<BlogsListContextProps>({
+  blogsList: null,
+  isLoading: true,
+});
+
+export const useBlogsList = () => {
+  const context = useContext(BlogsListContext);
+  if (!context) {
+    throw new Error("useBlogsList must be used within a BlogListProvider");
+  }
+  return context;
+};
+
+export const BlogsListProvider: React.FC<{
+  children: React.ReactNode;
+  locale: string;
+}> = ({ children, locale }) => {
+  const userLocale = locale;
+  const [blogsList, setBlogsList] = useState<Article[] | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    setIsLoading(true);
+    const fetchAndSetData = async () => {
+      const processedList: Article[] | undefined = await fetchAllBlogsList(
+        userLocale
+      );
+      if (!processedList) {
+        throw new Error("Failed to fetch service list");
+      }
+      setBlogsList(processedList);
+      setIsLoading(false);
+    };
+    fetchAndSetData();
+  }, [userLocale]);
+  const value = useMemo(
+    () => ({
+      isLoading,
+      blogsList,
+    }),
+    [isLoading, blogsList]
+  );
+
+  return (
+    <BlogsListContext.Provider value={value}>
+      {children}
+    </BlogsListContext.Provider>
+  );
+};

--- a/client/src/providers/BlogsProvider.tsx
+++ b/client/src/providers/BlogsProvider.tsx
@@ -1,0 +1,80 @@
+"use client";
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useMemo,
+} from "react";
+import { generate_item_url_from_blog_title } from "@/utils/functions";
+import { Article } from "@/libs/types/BlogsDataType";
+import { useBlogsList } from "./BlogsListProvider";
+import { fetchBlogsData } from "@/utils/fetch-blogs-data";
+
+interface BlogsContextType {
+  blogsItem: Article | null;
+  isLoading: boolean;
+}
+
+const BlogsContext = createContext<BlogsContextType>({
+  blogsItem: null,
+  isLoading: true,
+});
+
+interface BlogsProviderProps {
+  item: string;
+  children: React.ReactNode;
+  locale: string;
+}
+
+export const BlogsProvider: React.FC<BlogsProviderProps> = ({
+  item,
+  children,
+  locale,
+}) => {
+  const { blogsList } = useBlogsList();
+  const [blogsItem, setBlogsItem] = useState<Article | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const userLocale = locale;
+  useEffect(() => {
+    const blogsItemTemp =
+      blogsList &&
+      blogsList.find(
+        (sub) => generate_item_url_from_blog_title(sub.title) == item
+      );
+    if (blogsItemTemp) {
+      const fetchAndSetData = async () => {
+        const blogsItemTempData =
+          (await fetchBlogsData(blogsItemTemp.documentId, userLocale)) ?? "";
+        if (!blogsItemTempData) {
+          throw new Error("Failed to fetch service list");
+        }
+        setBlogsItem(blogsItemTempData);
+        setIsLoading(false);
+      };
+      setIsLoading(true);
+      fetchAndSetData();
+    }
+  }, [item, blogsList, userLocale]);
+  const contextValue = useMemo(
+    () => ({
+      blogsItem,
+      isLoading,
+    }),
+    [blogsItem, isLoading]
+  );
+
+  return (
+    <BlogsContext.Provider value={contextValue}>
+      {children}
+    </BlogsContext.Provider>
+  );
+};
+
+export const useBlogs = (): BlogsContextType => {
+  const context = useContext(BlogsContext);
+  if (!context) {
+    throw new Error("useBlogs must be used within a BlogsProvider");
+  }
+  return context;
+};

--- a/client/src/utils/fetch-all-blogs-list.ts
+++ b/client/src/utils/fetch-all-blogs-list.ts
@@ -1,0 +1,38 @@
+import { Article } from "@/libs/types/BlogsDataType";
+import { fetchAPI } from "./fetch-api";
+
+export async function fetchAllBlogsList(locale: string) {
+  let pageCount = 1;
+  let rawData: Article[] = [];
+  try {
+    let i = 1;
+    while (true) {
+      const path = "/articles";
+      const urlParamsObject = {
+        populate: ["Author", "article_category"],
+        sort: [{ date: "desc" }],
+        "[locale]": locale,
+        pagination: {
+          page: i,
+          pageSize: 100,
+        },
+      };
+      const responseData = await fetchAPI(path, urlParamsObject, "");
+      if (!responseData.data) break;
+      const tempRawData: Article[] = responseData.data;
+      rawData = [...rawData, ...tempRawData];
+      if (i == 1) {
+        pageCount = responseData.meta.pagination.pageCount;
+      }
+      i += 1;
+      if (i > pageCount) {
+        break;
+      }
+    }
+    return rawData;
+  } catch (err) {
+    const error =
+      err instanceof Error ? err : new Error("Failed to fetch data");
+    console.error("Error fetching services:", error);
+  }
+}

--- a/client/src/utils/fetch-blogs-data.ts
+++ b/client/src/utils/fetch-blogs-data.ts
@@ -1,0 +1,108 @@
+import { FreeServicesListType } from "@/libs/types/ListTypes";
+import { fetchAPI } from "./fetch-api";
+import { generate_item_url_from_name } from "./functions";
+import { getLocale } from "next-intl/server";
+import { fetchAllFreeServicesList } from "./fetch-all-free-services-list";
+import { BlogsItem } from "@/libs/types/BlogsItemsMapping";
+
+export async function fetchBlogsItemMappings(currentLocale: string) {
+  try {
+    let i = 1;
+    let pageCount = 1;
+    let data: BlogsItem[] = [];
+    while (true) {
+      const path = "/articles";
+      const urlParamsObject = {
+        fields: ["title", "locale"],
+        populate: {
+          localizations: {
+            fields: ["title", "locale"],
+          },
+        },
+        pagination: {
+          page: i,
+          pageSize: 100,
+        },
+        locale: currentLocale,
+      };
+      const response = await fetchAPI(path, urlParamsObject, "");
+      if (i == 1) {
+        pageCount = response.meta.pagination.pageCount;
+      }
+      const tempData = response.data;
+      data = [...data, ...tempData];
+      i += 1;
+      if (i > pageCount) {
+        break;
+      }
+    }
+    return data;
+  } catch (error) {
+    console.error("Error fetching service item mappings:", error);
+    return [];
+  }
+}
+
+export async function fetchBlogsData(itemId: string, locale: string) {
+  try {
+    const path = `/articles/${itemId}`;
+    const urlParamsObject = {
+      populate: [
+        "Author",
+        "Author.social",
+        "article_category",
+        "Content.Chapter.Header.text",
+        "Content.Chapter.Section.Header.text",
+        "Content.Chapter.Section.Subsection.Header.text",
+        "Content.Chapter.Section.Subsection.Paragraph.Sentence.text",
+        "Content.Chapter.Section.Subsection.Paragraph.List.Level1.Level2.text",
+        "Content.Chapter.Section.Subsection.Paragraph.List.Level1.text",
+        // "seo",
+        // "seo.openGraph",
+      ],
+      "[locale]": locale,
+    };
+    const options = "";
+    const fetchedData = await fetchAPI(path, urlParamsObject, options);
+    return fetchedData.data;
+  } catch (error) {
+    console.error(error);
+  }
+
+  return "";
+}
+
+export async function fetchBlogsMetaData(name: string) {
+  const locale = await getLocale();
+  const allData: FreeServicesListType[] =
+    (await fetchAllFreeServicesList(locale)) ?? [];
+  const freeTool = allData.find(
+    (sub) => generate_item_url_from_name(sub.name) == name
+  );
+  let itemId: string = "";
+  if (freeTool) {
+    itemId = freeTool.id;
+    try {
+      const path = `/sub-free-services/${itemId}`;
+      const urlParamsObject = {
+        fields: ["name", "locale"],
+        populate: {
+          seo: {
+            populate: ["openGraph"],
+          },
+          localizations: {
+            fields: ["name", "locale"],
+          },
+        },
+        "[locale]": locale,
+      };
+      const options = "";
+      const fetchedData = await fetchAPI(path, urlParamsObject, options);
+      return fetchedData.data;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  return "";
+}

--- a/client/src/utils/functions.ts
+++ b/client/src/utils/functions.ts
@@ -45,3 +45,22 @@ export function replace_str(s1: string, s2: string): string {
 
   return result;
 }
+
+export function format_blog_date(dateString: string): string {
+  const date = new Date(dateString);
+  // Options for formatting month as full name, day as number, year as number
+  const options: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  };
+  return date.toLocaleDateString("en-US", options);
+}
+
+export function generate_item_url_from_blog_title(title: string) {
+  const parts = title.split(/[:.?!,;\-]+/);
+  const mainPart = parts[0];
+  const words: string[] = mainPart.split(/[^a-zA-Z0-9]+/);
+  const filtered = words.filter(Boolean).map((word) => word.toLowerCase());
+  return filtered.join("-");
+}

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -19,6 +19,7 @@ export default {
       fontFamily: {
         satoshi: "Satoshi-Variable",
         clash: "Clashdisplay-Variable",
+        lato: "Lato",
       },
       colors: {
         "black-light": "#f6f6f6",


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new blog section by adding listing and detail page templates, data fetching providers, routing, and placeholders while integrating required utilities and styling enhancements.

New Features:
- Add blog listing (Posts, BlogsHero) and detail pages (BlogsDetailHero, BlogsDetailMain, BlogsDetailRelated) with dynamic routing under `/blog`
- Implement BlogsListProvider and BlogsProvider to fetch blog lists and individual articles from the API
- Add skeleton loaders for blog pages to show placeholders during data loading

Enhancements:
- Introduce utility functions `format_blog_date` and `generate_item_url_from_blog_title` for date formatting and slug generation
- Integrate Lato font via `next/font`, update global CSS, and configure Tailwind to include the new font and smooth scrolling
- Update navigation dropdown and footer links to reference the internal blog routes
- Allow gradient overlays in review components to hide when a “show less” button is present